### PR TITLE
Tweak the minimum version requirements in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.3.0",
         "monolog/monolog": "^1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": ">=3.5"
     },
     "suggest": {
         "ext-newrelic": "Adds support for viewing logs in context within the New Relic UI"


### PR DESCRIPTION
We'll match the PHP minimum requirement exactly to Monolog 1, which is 5.3.0. The unit tests require 5.3.3 (because PHPUnit 4.8 requires 5.3.3), but technically the runtime requirement is just 5.3.0.

We'll also require PHP_CodeSniffer 3.5 or later specifically, as we need the PSR-12 definition, and that was [added in 3.5.0](https://github.com/squizlabs/PHP_CodeSniffer/issues/750).