### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,36 +81,6 @@ jobs:
 
       - run: composer coding-standard-check
 
-  "php-5.4":
-    docker:
-      - image: php:5.4.45-cli
-
-    steps: *test_steps
-
-  "php-5.5":
-    docker:
-      - image: php:5.5.38-cli
-
-    steps: *test_steps
-
-  "php-5.6":
-    docker:
-      - image: php:5.6.40-cli
-
-    steps: *test_steps
-
-  "php-7.0":
-    docker:
-      - image: php:7.0.33-cli
-
-    steps: *test_steps
-
-  "php-7.1":
-    docker:
-      - image: php:7.1.33-cli
-
-    steps: *test_steps
-
   "php-7.2":
     docker:
       - image: php:7.2.25-cli
@@ -131,7 +101,7 @@ jobs:
 
   integration:
     docker:
-      - image: circleci/php:7-cli
+      - image: circleci/php:7.2-cli
 
     steps:
       - checkout
@@ -199,21 +169,6 @@ workflows:
   test:
     jobs:
       - coding_standard
-      - "php-5.4":
-          requires:
-            - coding_standard
-      - "php-5.5":
-          requires:
-            - coding_standard
-      - "php-5.6":
-          requires:
-            - coding_standard
-      - "php-7.0":
-          requires:
-            - coding_standard
-      - "php-7.1":
-          requires:
-            - coding_standard
       - "php-7.2":
           requires:
             - coding_standard


### PR DESCRIPTION
Since `monolog v2` only supports v2 and up, removed the PHP versions that `monolog v2` no longer supports from the CI.