### PR TITLE
reindex records before json_encode

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -52,6 +52,9 @@ class Formatter extends AbstractFormatter
 
             $records[$key] = $normalized;
         }
+
+        $records = array_values($records);
+
         return $this->toJson($records, true);
     }
 }


### PR DESCRIPTION
As soon as array_filter (in Handler::handleBatch()) will remove at least one element from anywhere but the end of the $records array, the array will not be numbered in a perfect sequence. The problem is, that an array that does not have a natural index sequence (starting at 0 and having no gaps afterwards) will lead to a different json format.